### PR TITLE
feat: support Laravel 13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,17 +8,56 @@ jobs:
     if: (!contains(github.event.head_commit.message, '[skip ci]'))
     strategy:
       matrix:
-        os: [ubuntu-24.04]
-        php: [8.2, 8.3]
-        laravel: [11.*, 12.*, 13.*]
-        dependency-version: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 11.*
+          - os: ubuntu-24.04
+            php: 8.2
+            laravel: 11.*
+            dependency-version: prefer-lowest
             testbench: ^9.2
-          - laravel: 12.*
-            testbench: 10.*
-          - laravel: 13.*
+          - os: ubuntu-24.04
+            php: 8.2
+            laravel: 11.*
+            dependency-version: prefer-stable
+            testbench: ^9.2
+          - os: ubuntu-24.04
             php: 8.3
+            laravel: 11.*
+            dependency-version: prefer-lowest
+            testbench: ^9.2
+          - os: ubuntu-24.04
+            php: 8.3
+            laravel: 11.*
+            dependency-version: prefer-stable
+            testbench: ^9.2
+          - os: ubuntu-24.04
+            php: 8.2
+            laravel: 12.*
+            dependency-version: prefer-lowest
+            testbench: 10.*
+          - os: ubuntu-24.04
+            php: 8.2
+            laravel: 12.*
+            dependency-version: prefer-stable
+            testbench: 10.*
+          - os: ubuntu-24.04
+            php: 8.3
+            laravel: 12.*
+            dependency-version: prefer-lowest
+            testbench: 10.*
+          - os: ubuntu-24.04
+            php: 8.3
+            laravel: 12.*
+            dependency-version: prefer-stable
+            testbench: 10.*
+          - os: ubuntu-24.04
+            php: 8.3
+            laravel: 13.*
+            dependency-version: prefer-lowest
+            testbench: ^11.0
+          - os: ubuntu-24.04
+            php: 8.3
+            laravel: 13.*
+            dependency-version: prefer-stable
             testbench: ^11.0
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,8 +74,5 @@ jobs:
       - run: composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update --dev
       - run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
-      - name: Migrate phpunit schema
-        run: vendor/bin/phpunit --migrate-configuration
-
       - name: Unit testing
         run: vendor/bin/phpunit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,8 +71,8 @@ jobs:
           php-version: ${{ matrix.php }}
           extensions: curl, pdo_sqlite
           coverage: none
-      - run: composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update --dev
-      - run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+      - run: composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update --no-blocking --dev
+      - run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-blocking
 
       - name: Unit testing
         run: vendor/bin/phpunit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,16 @@ jobs:
       matrix:
         os: [ubuntu-24.04]
         php: [8.2, 8.3]
-        laravel: [11.*, 12.*]
+        laravel: [11.*, 12.*, 13.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 11.*
             testbench: ^9.2
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 13.*
+            php: 8.3
+            testbench: ^11.0
 
     runs-on: ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Lime Newsletter is a Lime CRM add-on for creating and sending email campaigns an
 |-----------------|-----------------|
 | 7.x, 8.x,       | 1.x             |
 | 9.x, 10.x       | 2.x             |
-| 11.x, 12.x      | 3.x             |
+| 11.x, 12.x, 13.x| 3.x             |
 
 Add the following to your ``composer.json``
 
@@ -51,7 +51,7 @@ Add section to the **config/services.php** file:
 ],
 ```
 
-You also need to specify new available mail driver in **config/mail.php**:
+You also need to specify the newsletter mailer in **config/mail.php**:
 
 ```php
 'mailers' => [

--- a/composer.json
+++ b/composer.json
@@ -27,15 +27,15 @@
         }
     },
     "require-dev": {
-        "orchestra/testbench": "^9.2|^10.0",
+        "orchestra/testbench": "^9.2|^10.0|^11.0",
         "phpstan/phpstan": "^1.8",
-        "phpunit/phpunit": "^11.0",
+        "phpunit/phpunit": "^11.0|^12.0",
         "spatie/temporary-directory": "^2.2"
     },
     "require": {
         "php": "^8.2",
         "guzzlehttp/guzzle": "^7.0",
-        "illuminate/contracts": "^11.0|^12.0",
+        "illuminate/contracts": "^11.0|^12.0|^13.0",
         "symfony/mailer": "^7.0"
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,116 +1,101 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Property Lundalogik\\\\NewsletterDriver\\\\Newsletter\\\\SendTransactionMailArgs\\:\\:\\$fromName \\(string\\) does not accept string\\|null\\.$#"
+			message: '#^Property Lundalogik\\NewsletterDriver\\Newsletter\\SendTransactionMailArgs\:\:\$fromName \(string\) does not accept string\|null\.$#'
 			count: 1
 			path: src/Newsletter/SendTransactionMailArgs.php
 
 		-
-			message: "#^Property Lundalogik\\\\NewsletterDriver\\\\Newsletter\\\\SendTransactionMailArgs\\:\\:\\$toName \\(string\\) does not accept string\\|null\\.$#"
+			message: '#^Property Lundalogik\\NewsletterDriver\\Newsletter\\SendTransactionMailArgs\:\:\$toName \(string\) does not accept string\|null\.$#'
 			count: 1
 			path: src/Newsletter/SendTransactionMailArgs.php
 
 		-
-			message: "#^Method Lundalogik\\\\NewsletterDriver\\\\Newsletter\\\\SendingDomain\\:\\:all\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Lundalogik\\NewsletterDriver\\Newsletter\\SendingDomain\:\:all\(\) return type has no value type specified in iterable type array\.$#'
 			count: 1
 			path: src/Newsletter/SendingDomain.php
 
 		-
-			message: "#^Method Lundalogik\\\\NewsletterDriver\\\\Newsletter\\\\SendingDomain\\:\\:all\\(\\) should return array but returns mixed\\.$#"
+			message: '#^Method Lundalogik\\NewsletterDriver\\Newsletter\\SendingDomain\:\:all\(\) should return array but returns mixed\.$#'
 			count: 1
 			path: src/Newsletter/SendingDomain.php
 
 		-
-			message: "#^Method Lundalogik\\\\NewsletterDriver\\\\Newsletter\\\\SendingDomain\\:\\:validate\\(\\) has parameter \\$domain with no value type specified in iterable type array\\.$#"
+			message: '#^Method Lundalogik\\NewsletterDriver\\Newsletter\\SendingDomain\:\:validate\(\) has parameter \$domain with no value type specified in iterable type array\.$#'
 			count: 1
 			path: src/Newsletter/SendingDomain.php
 
 		-
-			message: "#^Method Lundalogik\\\\NewsletterDriver\\\\Newsletter\\\\TransactionMail\\:\\:sendBatch\\(\\) should return Response but returns Psr\\\\Http\\\\Message\\\\ResponseInterface\\.$#"
+			message: '#^Method Lundalogik\\NewsletterDriver\\Newsletter\\TransactionMail\:\:sendBatch\(\) should return Response but returns Psr\\Http\\Message\\ResponseInterface\.$#'
 			count: 1
 			path: src/Newsletter/TransactionMail.php
 
 		-
-			message: "#^Property Lundalogik\\\\NewsletterDriver\\\\NewsletterApi\\:\\:\\$domain has no type specified\\.$#"
+			message: '#^Property Lundalogik\\NewsletterDriver\\NewsletterApi\:\:\$domain has no type specified\.$#'
 			count: 1
 			path: src/NewsletterApi.php
 
 		-
-			message: "#^Property Lundalogik\\\\NewsletterDriver\\\\NewsletterApi\\:\\:\\$http has no type specified\\.$#"
+			message: '#^Property Lundalogik\\NewsletterDriver\\NewsletterApi\:\:\$http has no type specified\.$#'
 			count: 1
 			path: src/NewsletterApi.php
 
 		-
-			message: "#^Cannot access offset 'config' on Illuminate\\\\Contracts\\\\Foundation\\\\Application\\.$#"
-			count: 1
-			path: src/NewsletterMailServiceProvider.php
-
-		-
-			message: "#^Cannot call method extend\\(\\) on mixed\\.$#"
-			count: 1
-			path: src/NewsletterMailServiceProvider.php
-
-		-
-			message: "#^Method Lundalogik\\\\NewsletterDriver\\\\NewsletterMailServiceProvider\\:\\:provides\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/NewsletterMailServiceProvider.php
-
-		-
-			message: "#^Method Lundalogik\\\\NewsletterDriver\\\\Transport\\\\NewsletterTransport\\:\\:__construct\\(\\) has parameter \\$api with generic class Lundalogik\\\\NewsletterDriver\\\\Newsletter\\\\TransactionMail but does not specify its types\\: Response$#"
+			message: '#^Method Lundalogik\\NewsletterDriver\\Transport\\NewsletterTransport\:\:__construct\(\) has parameter \$api with generic class Lundalogik\\NewsletterDriver\\Newsletter\\TransactionMail but does not specify its types\: Response$#'
 			count: 1
 			path: src/Transport/NewsletterTransport.php
 
 		-
-			message: "#^Method Lundalogik\\\\NewsletterDriver\\\\Transport\\\\NewsletterTransport\\:\\:buildAttachmentModels\\(\\) should return array\\<Lundalogik\\\\NewsletterDriver\\\\Newsletter\\\\AttachmentModel\\> but returns array\\.$#"
+			message: '#^Method Lundalogik\\NewsletterDriver\\Transport\\NewsletterTransport\:\:buildAttachmentModels\(\) should return array\<Lundalogik\\NewsletterDriver\\Newsletter\\AttachmentModel\> but returns array\.$#'
 			count: 1
 			path: src/Transport/NewsletterTransport.php
 
 		-
-			message: "#^Parameter \\#1 \\$content of method Lundalogik\\\\NewsletterDriver\\\\Newsletter\\\\SendTransactionMailArgs\\:\\:htmlContent\\(\\) expects string, resource\\|string\\|null given\\.$#"
+			message: '#^Parameter \#1 \$content of method Lundalogik\\NewsletterDriver\\Newsletter\\SendTransactionMailArgs\:\:htmlContent\(\) expects string, resource\|string\|null given\.$#'
 			count: 1
 			path: src/Transport/NewsletterTransport.php
 
 		-
-			message: "#^Parameter \\#1 \\$name of method Lundalogik\\\\NewsletterDriver\\\\Newsletter\\\\AttachmentModel\\:\\:fileNameWithExtension\\(\\) expects string, string\\|null given\\.$#"
+			message: '#^Parameter \#1 \$name of method Lundalogik\\NewsletterDriver\\Newsletter\\AttachmentModel\:\:fileNameWithExtension\(\) expects string, string\|null given\.$#'
 			count: 1
 			path: src/Transport/NewsletterTransport.php
 
 		-
-			message: "#^Parameter \\#1 \\$subject of method Lundalogik\\\\NewsletterDriver\\\\Newsletter\\\\SendTransactionMailArgs\\:\\:subject\\(\\) expects string, string\\|null given\\.$#"
+			message: '#^Parameter \#1 \$subject of method Lundalogik\\NewsletterDriver\\Newsletter\\SendTransactionMailArgs\:\:subject\(\) expects string, string\|null given\.$#'
 			count: 1
 			path: src/Transport/NewsletterTransport.php
 
 		-
-			message: "#^Property Lundalogik\\\\NewsletterDriver\\\\Transport\\\\NewsletterTransport\\:\\:\\$api with generic class Lundalogik\\\\NewsletterDriver\\\\Newsletter\\\\TransactionMail does not specify its types\\: Response$#"
+			message: '#^Property Lundalogik\\NewsletterDriver\\Transport\\NewsletterTransport\:\:\$api with generic class Lundalogik\\NewsletterDriver\\Newsletter\\TransactionMail does not specify its types\: Response$#'
 			count: 1
 			path: src/Transport/NewsletterTransport.php
 
 		-
-			message: "#^Cannot access offset 'FileNameWithExtensi…' on mixed\\.$#"
+			message: '#^Cannot access offset ''FileNameWithExtensi…'' on mixed\.$#'
 			count: 1
 			path: tests/Unit/NewsletterTransportTest.php
 
 		-
-			message: "#^Cannot access offset 0 on mixed\\.$#"
+			message: '#^Cannot access offset 0 on mixed\.$#'
 			count: 2
 			path: tests/Unit/NewsletterTransportTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
+			message: '#^Parameter \#1 \$value of function count expects array\|Countable, mixed given\.$#'
 			count: 1
 			path: tests/Unit/NewsletterTransportTest.php
 
 		-
-			message: "#^Cannot access offset 'request' on mixed\\.$#"
+			message: '#^Cannot access offset ''request'' on mixed\.$#'
 			count: 1
 			path: tests/Unit/SendBatchTest.php
 
 		-
-			message: "#^Cannot call method getBody\\(\\) on mixed\\.$#"
+			message: '#^Cannot call method getBody\(\) on mixed\.$#'
 			count: 1
 			path: tests/Unit/SendBatchTest.php
 
 		-
-			message: "#^Cannot call method getUri\\(\\) on mixed\\.$#"
+			message: '#^Cannot call method getUri\(\) on mixed\.$#'
 			count: 1
 			path: tests/Unit/SendBatchTest.php

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,23 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  bootstrap="vendor/autoload.php"
-  backupGlobals="false"
-  backupStaticAttributes="false"
-  colors="true"
-  verbose="true"
-  convertErrorsToExceptions="true"
-  convertNoticesToExceptions="true"
-  convertWarningsToExceptions="true"
-  processIsolation="false"
-  stopOnFailure="false"
-  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
->
-  <coverage>
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticProperties="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.5/phpunit.xsd">
   <testsuites>
     <testsuite name="Unit">
       <directory suffix="Test.php">./tests/Unit</directory>
@@ -27,4 +9,9 @@
     <env name="DB_CONNECTION" value="testing"/>
     <env name="APP_KEY" value="base64:2fl+Ktvkfl+Fuz4Qp/A75G2RTiWVA/ZoKZvp6fiiM10="/>
   </php>
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/NewsletterMailServiceProvider.php
+++ b/src/NewsletterMailServiceProvider.php
@@ -30,9 +30,7 @@ class NewsletterMailServiceProvider extends ServiceProvider
         // register a custom api class for newsletter, which can contain operations that are not related to mailing/backend work.
         // see here: https://stackoverflow.com/questions/45794683/how-to-create-aliases-in-laravel
         $this->app->singleton(NewsletterApi::class, function () {
-            $client = $this->getHttpClient();
-
-            return new NewsletterApi($client);
+            return new NewsletterApi($this->getHttpClient());
         });
     }
 
@@ -43,10 +41,8 @@ class NewsletterMailServiceProvider extends ServiceProvider
      */
     protected function newsletterTransport(array $config = []): NewsletterTransport
     {
-        $client = $this->getHttpClient($config);
-
         return new NewsletterTransport(
-            new TransactionMail($client)
+            new TransactionMail($this->getHttpClient($config))
         );
     }
 

--- a/src/NewsletterMailServiceProvider.php
+++ b/src/NewsletterMailServiceProvider.php
@@ -3,64 +3,87 @@
 namespace Lundalogik\NewsletterDriver;
 
 use GuzzleHttp\Client;
-use Illuminate\Mail\MailServiceProvider;
+use Illuminate\Config\Repository as ConfigRepository;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\ServiceProvider;
 use Lundalogik\NewsletterDriver\Newsletter\TransactionMail;
 use Lundalogik\NewsletterDriver\Transport\NewsletterTransport;
 
-class NewsletterMailServiceProvider extends MailServiceProvider
+class NewsletterMailServiceProvider extends ServiceProvider
 {
     /**
-     * Register the Illuminate mailer instance.
-     *
      * @return void
      */
-    protected function registerIlluminateMailer()
+    public function boot(): void
     {
-        parent::registerIlluminateMailer();
-
-        app('mail.manager')->extend('newsletter', function () {
-            return $this->newsletterTransport();
+        Mail::extend('newsletter', function (array $config = []) {
+            return $this->newsletterTransport($config);
         });
     }
 
+    /**
+     * @return void
+     */
     public function register()
     {
-        parent::register();
         // register a custom api class for newsletter, which can contain operations that are not related to mailing/backend work.
         // see here: https://stackoverflow.com/questions/45794683/how-to-create-aliases-in-laravel
         $this->app->singleton(NewsletterApi::class, function () {
             $client = $this->getHttpClient();
+
             return new NewsletterApi($client);
         });
     }
 
-    protected function newsletterTransport(): NewsletterTransport
+    /**
+     * @param array<string, mixed> $config
+     *
+     * @return NewsletterTransport
+     */
+    protected function newsletterTransport(array $config = []): NewsletterTransport
     {
-        $client = $this->getHttpClient();
+        $client = $this->getHttpClient($config);
 
         return new NewsletterTransport(
             new TransactionMail($client)
         );
     }
 
-    public function provides()
+    /**
+     * @return class-string[]
+     */
+    public function provides(): array
     {
-        return array_merge(parent::provides(), [
-            NewsletterApi::class
-        ]);
+        return [
+            NewsletterApi::class,
+        ];
     }
 
-    protected function getHttpClient(): Client
+    /**
+     * @param array<string, mixed> $config
+     *
+     * @return Client
+     */
+    protected function getHttpClient(array $config = []): Client
     {
-        $config = $this->app['config']->get('services.newsletter', []);
+        /** @var ConfigRepository $appConfig */
+        $appConfig = $this->app->make('config');
+        $serviceConfig = $appConfig->array('services.newsletter', []);
 
-        $client = new Client([
-            'base_uri' => "{$config['base_url']}{$config['account']}/api/",
+        $config = array_merge($serviceConfig, $config);
+
+        $baseUrl = Arr::string($config, 'base_url');
+        $account = Arr::string($config, 'account');
+        $apiKey = Arr::string($config, 'api_key');
+        $userEmail = Arr::string($config, 'user_email');
+
+        return new Client([
+            'base_uri' => "{$baseUrl}{$account}/api/",
             'headers' => [
-                'apikey' => $config['api_key'],
-                'useremail' => $config['user_email'],
+                'apikey' => $apiKey,
+                'useremail' => $userEmail,
             ],
         ]);
-        return $client;
     }
 }

--- a/src/NewsletterMailServiceProvider.php
+++ b/src/NewsletterMailServiceProvider.php
@@ -6,7 +6,6 @@ use GuzzleHttp\Client;
 use Illuminate\Config\Repository as ConfigRepository;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\ServiceProvider;
-use InvalidArgumentException;
 use Lundalogik\NewsletterDriver\Newsletter\TransactionMail;
 use Lundalogik\NewsletterDriver\Transport\NewsletterTransport;
 
@@ -65,14 +64,16 @@ class NewsletterMailServiceProvider extends ServiceProvider
     {
         /** @var ConfigRepository $appConfig */
         $appConfig = $this->app->make('config');
+        /** @var array<string, scalar|null> $serviceConfig */
         $serviceConfig = $appConfig->array('services.newsletter', []);
 
+        /** @var array<string, scalar|null> $config */
         $config = array_merge($serviceConfig, $config);
 
-        $baseUrl = $this->stringValue($config, 'base_url');
-        $account = $this->stringValue($config, 'account');
-        $apiKey = $this->stringValue($config, 'api_key');
-        $userEmail = $this->stringValue($config, 'user_email');
+        $baseUrl = (string) ($config['base_url'] ?? '');
+        $account = (string) ($config['account'] ?? '');
+        $apiKey = (string) ($config['api_key'] ?? '');
+        $userEmail = (string) ($config['user_email'] ?? '');
 
         return new Client([
             'base_uri' => "{$baseUrl}{$account}/api/",
@@ -81,24 +82,5 @@ class NewsletterMailServiceProvider extends ServiceProvider
                 'useremail' => $userEmail,
             ],
         ]);
-    }
-
-    /**
-     * @param array<string, mixed> $config
-     * @param string $key
-     *
-     * @return string
-     *
-     * @throws InvalidArgumentException
-     */
-    protected function stringValue(array $config, string $key): string
-    {
-        $value = $config[$key] ?? null;
-
-        if (is_string($value) === false) {
-            throw new InvalidArgumentException("Newsletter config '{$key}' must be a string.");
-        }
-
-        return $value;
     }
 }

--- a/src/NewsletterMailServiceProvider.php
+++ b/src/NewsletterMailServiceProvider.php
@@ -4,9 +4,9 @@ namespace Lundalogik\NewsletterDriver;
 
 use GuzzleHttp\Client;
 use Illuminate\Config\Repository as ConfigRepository;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\ServiceProvider;
+use InvalidArgumentException;
 use Lundalogik\NewsletterDriver\Newsletter\TransactionMail;
 use Lundalogik\NewsletterDriver\Transport\NewsletterTransport;
 
@@ -69,10 +69,10 @@ class NewsletterMailServiceProvider extends ServiceProvider
 
         $config = array_merge($serviceConfig, $config);
 
-        $baseUrl = Arr::string($config, 'base_url');
-        $account = Arr::string($config, 'account');
-        $apiKey = Arr::string($config, 'api_key');
-        $userEmail = Arr::string($config, 'user_email');
+        $baseUrl = $this->stringValue($config, 'base_url');
+        $account = $this->stringValue($config, 'account');
+        $apiKey = $this->stringValue($config, 'api_key');
+        $userEmail = $this->stringValue($config, 'user_email');
 
         return new Client([
             'base_uri' => "{$baseUrl}{$account}/api/",
@@ -81,5 +81,24 @@ class NewsletterMailServiceProvider extends ServiceProvider
                 'useremail' => $userEmail,
             ],
         ]);
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     * @param string $key
+     *
+     * @return string
+     *
+     * @throws InvalidArgumentException
+     */
+    protected function stringValue(array $config, string $key): string
+    {
+        $value = $config[$key] ?? null;
+
+        if (is_string($value) === false) {
+            throw new InvalidArgumentException("Newsletter config '{$key}' must be a string.");
+        }
+
+        return $value;
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,11 +2,16 @@
 
 namespace Lundalogik\NewsletterDriver\Tests;
 
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Lundalogik\NewsletterDriver\NewsletterMailServiceProvider;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
 
 class TestCase extends OrchestraTestCase
 {
+    /**
+     * @return void
+     */
     public function setUp(): void
     {
         parent::setUp();
@@ -14,10 +19,42 @@ class TestCase extends OrchestraTestCase
         // additional setup ..
     }
 
+    /**
+     * @param mixed $app
+     *
+     * @return class-string[]
+     */
     protected function getPackageProviders($app)
     {
         return [
             NewsletterMailServiceProvider::class,
         ];
+    }
+
+    /**
+     * @param mixed $app
+     *
+     * @return void
+     */
+    protected function defineEnvironment($app): void
+    {
+        /** @var Application $app */
+        /** @var ConfigRepository $config */
+        $config = $app->make('config');
+
+        $config->set('mail.default', 'newsletter');
+        $config->set('mail.mailers.newsletter', [
+            'transport' => 'newsletter',
+            'api_key' => 'test-api-key',
+            'user_email' => 'test@example.com',
+            'account' => 'test-account',
+            'base_url' => 'https://qa.bwz.se/bedrock/',
+        ]);
+        $config->set('services.newsletter', [
+            'api_key' => 'test-api-key',
+            'user_email' => 'test@example.com',
+            'account' => 'test-account',
+            'base_url' => 'https://qa.bwz.se/bedrock/',
+        ]);
     }
 }

--- a/tests/Unit/NewsletterMailServiceProviderTest.php
+++ b/tests/Unit/NewsletterMailServiceProviderTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Lundalogik\NewsletterDriver\Tests\Unit;
+
+use Illuminate\Mail\Mailer;
+use Illuminate\Support\Facades\Mail;
+use Lundalogik\NewsletterDriver\Tests\TestCase;
+use Lundalogik\NewsletterDriver\Transport\NewsletterTransport;
+
+class NewsletterMailServiceProviderTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function test_it_registers_the_newsletter_transport_with_the_mail_manager(): void
+    {
+        /** @var Mailer $mailer */
+        $mailer = Mail::mailer('newsletter');
+        $transport = $mailer->getSymfonyTransport();
+
+        $this->assertInstanceOf(NewsletterTransport::class, $transport);
+        $this->assertSame('newsletter', (string) $transport);
+    }
+}


### PR DESCRIPTION
## Summary
- add Laravel 13 package support in Composer and CI, including Testbench 11 coverage
- move newsletter transport registration onto Laravel's supported `Mail::extend(...)` integration path
- add package-level coverage for resolving the custom newsletter transport through the mail manager and update PHPUnit configuration for PHPUnit 12

## Testing
- `docker run --rm --network container:lime-forms-php -v \"/Users/adamczykpiotr/repos/laravel-newsletter-driver-l13:/var/www/html\" -w /var/www/html lime-forms-php vendor/bin/phpunit`
- `docker run --rm --network container:lime-forms-php -v \"/Users/adamczykpiotr/repos/laravel-newsletter-driver-l13:/var/www/html\" -w /var/www/html lime-forms-php vendor/bin/phpstan analyse --memory-limit=512M`